### PR TITLE
Fix the GestureTest example

### DIFF
--- a/Libraries/Arduino/examples/GestureTest/GestureTest.ino
+++ b/Libraries/Arduino/examples/GestureTest/GestureTest.ino
@@ -55,7 +55,7 @@ Distributed as-is; no warranty is given.
 
 // Global Variables
 SparkFun_APDS9960 apds = SparkFun_APDS9960();
-int isr_flag = 0;
+volatile int isr_flag = 0;
 
 void setup() {
 
@@ -70,7 +70,7 @@ void setup() {
   Serial.println(F("--------------------------------"));
   
   // Initialize interrupt service routine
-  attachInterrupt(0, interruptRoutine, FALLING);
+  attachInterrupt(digitalPinToInterrupt(APDS9960_INT), interruptRoutine, FALLING);
 
   // Initialize APDS-9960 (configure I2C and initial values)
   if ( apds.init() ) {
@@ -89,10 +89,10 @@ void setup() {
 
 void loop() {
   if( isr_flag == 1 ) {
-    detachInterrupt(0);
+    detachInterrupt(digitalPinToInterrupt(APDS9960_INT));
     handleGesture();
     isr_flag = 0;
-    attachInterrupt(0, interruptRoutine, FALLING);
+    attachInterrupt(digitalPinToInterrupt(APDS9960_INT), interruptRoutine, FALLING);
   }
 }
 


### PR DESCRIPTION
Resolve the interrupt number with digitalPinToInterrupt() instead of
hardcoding it to "0". This is the recommended method from
https://www.arduino.cc/en/Reference/attachInterrupt

It should work with post-2014 releases of any Arduino IDE version.
(1.0.x, 1.5.x, 1.6.x)

Also declare the isr_flag as volatile. It will not make a difference
here but can break code if this example is extended further.