### PR TITLE
Add GY-9960LLC APDS-9960 sensor support

### DIFF
--- a/Libraries/Arduino/APDS-9960_RGB_and_Gesture_Sensor_Arduino_Library/library.properties
+++ b/Libraries/Arduino/APDS-9960_RGB_and_Gesture_Sensor_Arduino_Library/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun APDS9960 RGB and Gesture Sensor
-version=1.4.3
+version=1.4.4
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for the Avago APDS-9960 sensor

--- a/Libraries/Arduino/APDS-9960_RGB_and_Gesture_Sensor_Arduino_Library/src/SparkFun_APDS9960.cpp
+++ b/Libraries/Arduino/APDS-9960_RGB_and_Gesture_Sensor_Arduino_Library/src/SparkFun_APDS9960.cpp
@@ -63,7 +63,7 @@ bool SparkFun_APDS9960::init()
     if( !wireReadDataByte(APDS9960_ID, id) ) {
         return false;
     }
-    if( !(id == APDS9960_ID_1 || id == APDS9960_ID_2) ) {
+    if( !(id == APDS9960_ID_1 || id == APDS9960_ID_2 || id == APDS9960_ID_3) ) {
         return false;
     }
      

--- a/Libraries/Arduino/APDS-9960_RGB_and_Gesture_Sensor_Arduino_Library/src/SparkFun_APDS9960.h
+++ b/Libraries/Arduino/APDS-9960_RGB_and_Gesture_Sensor_Arduino_Library/src/SparkFun_APDS9960.h
@@ -33,6 +33,7 @@
 /* Acceptable device IDs */
 #define APDS9960_ID_1           0xAB
 #define APDS9960_ID_2           0x9C 
+#define APDS9960_ID_3           0xA8 
 
 /* Misc parameters */
 #define FIFO_PAUSE_TIME         30      // Wait period (ms) between FIFO reads


### PR DESCRIPTION
Hi,

the  [GY-9960LLC APDS-9960](https://de.aliexpress.com/item/GY-9960LLC-APDS-9960-RGB-and-Gesture-Sensor-Module-I2C-Breakout-for-Arduino/32738206621.html?spm=a2g0s.9042311.0.0.3a834c4dDBCR8o)  sensor reports a different ID: `0xA8`.
The library works perfectly with that sensor but the ID is missing so the initialization is failing. This fixes this.